### PR TITLE
feat: make max file size configurable via asset upload settings

### DIFF
--- a/src/files-and-videos/files-page/FilesPage.jsx
+++ b/src/files-and-videos/files-page/FilesPage.jsx
@@ -1,10 +1,12 @@
 import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { useDispatch, useSelector } from 'react-redux';
+import { getConfig } from '@edx/frontend-platform';
 import { injectIntl, FormattedMessage, intlShape } from '@edx/frontend-platform/i18n';
 import { CheckboxFilter, Container } from '@openedx/paragon';
 import Placeholder from '../../editors/Placeholder';
 
+import { UPLOAD_FILE_MAX_SIZE } from '../../constants';
 import { RequestStatus } from '../../data/constants';
 import { useModels, useModel } from '../../generic/model-store';
 import {
@@ -91,7 +93,7 @@ const FilesPage = ({
     usageErrorMessages: errorMessages.usageMetrics,
     fileType: 'file',
   };
-  const maxFileSize = 20 * 1048576;
+  const maxFileSize = getConfig().MAX_ASSET_UPLOAD_FILE_SIZE_IN_MB * 1024 * 1024 || UPLOAD_FILE_MAX_SIZE;
 
   const activeColumn = {
     id: 'activeStatus',


### PR DESCRIPTION
## Description
This PR makes the maximum file size for asset uploads configurable through the application configuration. 

Previously, the limit was hardcoded to a fixed value. Now, the system attempts to fetch `MAX_ASSET_UPLOAD_FILE_SIZE_IN_MB` from the configuration. If this value is not defined or the API call fails, it gracefully falls back to the constant `UPLOAD_FILE_MAX_SIZE`.

## Changes
- Replaced hardcoded `maxFileSize` constant with a dynamic configuration lookup.
- Added a fallback mechanism to ensure uploads continue to work even if the configuration is missing.
- Converted the configuration value (MB) to bytes for internal validation logic.

## Screenshots

### Before
- Hardcoded value: `20 * 1048576` (Fixed 20MB).
- 
<img width="1837" height="896" alt="image" src="https://github.com/user-attachments/assets/5af47e7a-c6f0-4921-b54a-2651fd78e6ba" />


### After
- Dynamic value: `getConfig().MAX_ASSET_UPLOAD_FILE_SIZE_IN_MB` with fallback to `UPLOAD_FILE_MAX_SIZE`.
- 
<img width="1902" height="974" alt="image" src="https://github.com/user-attachments/assets/0873d1cf-dfdd-4d4a-9046-212492d9095e" />
