### PR TITLE
feat: authoring MFE deployment action

### DIFF
--- a/.github/workflows/deploy-mfe.yml
+++ b/.github/workflows/deploy-mfe.yml
@@ -1,0 +1,38 @@
+# This workflow deploys a Micro Frontend (MFE) application to an bucket
+#
+# Purpose:
+# - Deploys the compiled frontend assets to a bucket for hosting
+# - Uses a reusable workflow from nelc/actions-hub
+# - Can target either staging or production environments
+#
+# Trigger:
+# - Manual trigger only (workflow_dispatch)
+#
+# Inputs:
+# - environment: Choose between 'stage' (default) or 'prod' environments
+#
+# Notes:
+# - For production deployments, the workflow must be run from the production branch
+# - Stage deployments can be run from any branch
+
+name: MFE Bucket Deployment 🚀
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Environment to deploy:'
+        required: true
+        default: 'stage'
+        type: choice
+        options:
+          - stage
+          - prod
+
+jobs:
+  deploy_mfe:
+    name: Deploy ${{ inputs.environment }}
+    uses: nelc/actions-hub/.github/workflows/mfe-bucket-deployment.yml@main
+    with:
+      ENVIRONMENT: ${{ inputs.environment }}
+    secrets: inherit


### PR DESCRIPTION
## Description
Adds the manual deployment workflow (`MFE Bucket Deployment 🚀`) to allow deploying the Micro Frontend (MFE) application to specified environments (`stage` or `prod`).

Issue # [1504](https://edunext.atlassian.net/browse/FUTUREX-1504)
Migration pr of #16 and #29 

## Changes Included
* Introduced the GitHub Actions workflow file for MFE bucket deployments.
* Configured manual trigger (`workflow_dispatch`) with environment selection (`stage` / `prod`).
* Integrated the reusable workflow `nelc/actions-hub/.github/workflows/mfe-bucket-deployment.yml@main`.

## How to Test
1. Go to the **Actions** tab in GitHub.
2. Select the **MFE Bucket Deployment 🚀** workflow.
3. Click **Run workflow**, choose either `stage` or `prod`, and trigger the run.

