### PR TITLE
feat: remove preview button

### DIFF
--- a/src/course-unit/CourseUnit.test.tsx
+++ b/src/course-unit/CourseUnit.test.tsx
@@ -197,8 +197,6 @@ describe('<CourseUnit />', () => {
       .toBeInTheDocument();
     expect(await screen.findByRole('button', { name: headerNavigationsMessages.viewLiveButton.defaultMessage }))
       .toBeInTheDocument();
-    expect(await screen.findByRole('button', { name: headerNavigationsMessages.previewButton.defaultMessage }))
-      .toBeInTheDocument();
     expect(await screen.findByRole('button', { name: currentSectionName })).toBeInTheDocument();
     expect(await screen.findByRole('button', { name: currentSubSectionName })).toBeInTheDocument();
   });
@@ -650,7 +648,6 @@ describe('<CourseUnit />', () => {
     window.open = jest.fn();
     render(<RootWrapper />);
     const {
-      draft_preview_link: draftPreviewLink,
       published_preview_link: publishedPreviewLink,
     } = courseSectionVerticalMock;
 
@@ -660,13 +657,6 @@ describe('<CourseUnit />', () => {
     await user.click(viewLiveButton);
     expect(window.open).toHaveBeenCalled();
     expect(window.open).toHaveBeenCalledWith(publishedPreviewLink, '_blank');
-
-    const previewButton = await screen.findByRole('button', {
-      name: headerNavigationsMessages.previewButton.defaultMessage,
-    });
-    await user.click(previewButton);
-    expect(window.open).toHaveBeenCalled();
-    expect(window.open).toHaveBeenCalledWith(draftPreviewLink, '_blank');
 
     window.open = open;
   });

--- a/src/course-unit/header-navigations/HeaderNavigations.test.tsx
+++ b/src/course-unit/header-navigations/HeaderNavigations.test.tsx
@@ -8,13 +8,11 @@ import HeaderNavigations from './HeaderNavigations';
 import messages from './messages';
 
 const handleViewLiveFn = jest.fn();
-const handlePreviewFn = jest.fn();
 const handleEditFn = jest.fn();
 const mockSetCurrentPageKey = jest.fn();
 
 const headerNavigationsActions = {
   handleViewLive: handleViewLiveFn,
-  handlePreview: handlePreviewFn,
   handleEdit: handleEditFn,
 };
 
@@ -45,7 +43,6 @@ describe('<HeaderNavigations />', () => {
     renderComponent({ unitCategory: COURSE_BLOCK_NAMES.vertical.id });
 
     expect(screen.getByRole('button', { name: messages.viewLiveButton.defaultMessage })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: messages.previewButton.defaultMessage })).toBeInTheDocument();
   });
 
   it('calls the correct handlers when clicking buttons for unit page', async () => {
@@ -55,10 +52,6 @@ describe('<HeaderNavigations />', () => {
     const viewLiveButton = screen.getByRole('button', { name: messages.viewLiveButton.defaultMessage });
     await user.click(viewLiveButton);
     expect(handleViewLiveFn).toHaveBeenCalledTimes(1);
-
-    const previewButton = screen.getByRole('button', { name: messages.previewButton.defaultMessage });
-    await user.click(previewButton);
-    expect(handlePreviewFn).toHaveBeenCalledTimes(1);
 
     const editButton = screen.queryByRole('button', { name: messages.editButton.defaultMessage });
     expect(editButton).not.toBeInTheDocument();

--- a/src/course-unit/header-navigations/HeaderNavigations.tsx
+++ b/src/course-unit/header-navigations/HeaderNavigations.tsx
@@ -7,7 +7,6 @@ import {
 import {
   Add,
   Edit as EditIcon,
-  FindInPage,
   InfoOutline,
 } from '@openedx/paragon/icons';
 import { COURSE_BLOCK_NAMES } from '@src/constants';
@@ -18,7 +17,6 @@ import { useUnitSidebarContext } from '../unit-sidebar/UnitSidebarContext';
 
 export type HeaderNavigationActions = {
   handleViewLive: () => void;
-  handlePreview: () => void;
   handleEdit: () => void;
 };
 
@@ -42,7 +40,6 @@ const HeaderNavigations = ({
   const intl = useIntl();
   const {
     handleViewLive,
-    handlePreview,
     handleEdit,
   } = headerNavigationsActions;
 
@@ -80,13 +77,6 @@ const HeaderNavigations = ({
             </>
           )}
           <ButtonGroup>
-            <Button
-              variant="outline-primary"
-              onClick={handlePreview}
-              iconBefore={FindInPage}
-            >
-              {intl.formatMessage(messages.previewButton)}
-            </Button>
             {/* TODO: convert to <Button as="a" href="..."> since it navigates to a URL */}
             <Button
               variant="outline-primary"


### PR DESCRIPTION
## Description
This removes the unit preview button

Issue # [1505](https://edunext.atlassian.net/browse/FUTUREX-1505)
Migration pr of #20

## How to test 
1. Go to any course unit and verify that the preview button doesn't appear

## Before
<img width="1904" height="656" alt="image" src="https://github.com/user-attachments/assets/eae9d31c-d027-4401-82bf-f7fa0e4b5a58" />


## After
<img width="1904" height="656" alt="image" src="https://github.com/user-attachments/assets/5c71eaec-4763-40b4-84b0-ab820ee6ea5f" />