### PR TITLE
feat: add frontend-essentials translations to makefile command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,9 +38,10 @@ pull_translations:
 	            translations/frontend-platform/src/i18n/messages:frontend-platform \
 	            translations/paragon/src/i18n/messages:paragon \
 	            translations/frontend-component-footer/src/i18n/messages:frontend-component-footer \
-	            translations/frontend-app-course-authoring/src/i18n/messages:frontend-app-course-authoring
+	            translations/frontend-app-course-authoring/src/i18n/messages:frontend-app-course-authoring \
+	            translations/frontend-essentials/src/i18n/messages:frontend-essentials
 
-	$(intl_imports) frontend-component-ai-translations frontend-platform paragon frontend-component-footer frontend-app-course-authoring
+	$(intl_imports) frontend-component-ai-translations frontend-platform paragon frontend-component-footer frontend-app-course-authoring frontend-essentials
 
 # This target is used by Travis.
 validate-no-uncommitted-package-lock-changes:


### PR DESCRIPTION
## Description

This adds the frontend-essentials package to the pull_translation workflow. 

Issue # [1508](https://edunext.atlassian.net/browse/FUTUREX-1508)
Migration pr of #19 

## How to test
1. Run the following commands
``` bash
export PATH="$(pwd)/node_modules/.bin:$PATH"
make OPENEDX_ATLAS_PULL=true ATLAS_OPTIONS="--repository=nelc/futurex-translations --revision=open-release/redwood.master" pull_translations
```
2. Check the content of the folder` frontend-app-authoring/src/i18n/messages` 

<img width="509" height="822" alt="image" src="https://github.com/user-attachments/assets/d59b82a7-a785-43a9-8db3-c180534ea5a1" />

3. Check any essetial component translation

<img width="1915" height="918" alt="image" src="https://github.com/user-attachments/assets/6de84377-6492-43cd-b566-400b479e1e1a" />
