### PR TITLE
feat: make max file size configurable via asset upload settings

### DIFF
--- a/src/files-and-videos/files-page/CourseFilesTable.tsx
+++ b/src/files-and-videos/files-page/CourseFilesTable.tsx
@@ -1,3 +1,4 @@
+import { getConfig } from '@edx/frontend-platform';
 import { useIntl } from '@edx/frontend-platform/i18n';
 import { CheckboxFilter } from '@openedx/paragon';
 import { AgreementGated, UPLOAD_FILE_MAX_SIZE } from '@src/constants';
@@ -88,7 +89,7 @@ export const CourseFilesTable = () => {
     usageErrorMessages: errorMessages.usageMetrics,
     fileType: 'file',
   };
-  const maxFileSize = UPLOAD_FILE_MAX_SIZE;
+  const maxFileSize = getConfig().MAX_ASSET_UPLOAD_FILE_SIZE_IN_MB * 1024 * 1024 || UPLOAD_FILE_MAX_SIZE;
 
   const activeColumn = {
     id: 'activeStatus',


### PR DESCRIPTION
## Description
This PR makes the maximum file size for asset uploads configurable through the application configuration. 

Previously, the limit was hardcoded to a fixed value. Now, the system attempts to fetch `MAX_ASSET_UPLOAD_FILE_SIZE_IN_MB` from the configuration. If this value is not defined or the API call fails, it gracefully falls back to the constant `UPLOAD_FILE_MAX_SIZE`.

Issue # [1725](https://edunext.atlassian.net/browse/FUTUREX-1725)
Migration pr of #28 

## Changes
- Replaced hardcoded `maxFileSize` constant with a dynamic configuration lookup.
- Added a fallback mechanism to ensure uploads continue to work even if the configuration is missing.
- Converted the configuration value (MB) to bytes for internal validation logic.

## Screenshots

### Before
- Hardcoded value: `20 * 1048576` (Fixed 20MB).
<img width="1915" height="918" alt="image" src="https://github.com/user-attachments/assets/8b4f7b67-0c15-41dc-85d5-69605df977fc" />



### After
- Dynamic value: `getConfig().MAX_ASSET_UPLOAD_FILE_SIZE_IN_MB` with fallback to `UPLOAD_FILE_MAX_SIZE`.
<img width="1915" height="918" alt="image" src="https://github.com/user-attachments/assets/2151940e-79c4-4da4-8431-e2227a27537c" />

